### PR TITLE
add system-wide installation option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,57 +1,74 @@
-#设置工程名称
-
+# Set the project name
 CMAKE_POLICY(SET CMP0048 NEW)
-#SET(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum OS X deployment version")
 PROJECT(MDictCpp VERSION 1.0.0)
 
-#设置CMAKE最小版本
+# Set the minimum required CMake version
 CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
 
+# C++ standard
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
-
-#设置构建类型，及相应的编译选项
+# Set build type and compilation flags
 SET(CMAKE_BUILD_TYPE "Debug")
+SET(CMAKE_CXX_FLAGS_DEBUG "$ENV{CXXFLAGS} -O0 -Wall -g -ggdb --std=c++11 ")
+SET(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall --std=c++11 ")
 
-# SET(CMAKE_OSX_SYSROOT "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
-# SET(CMAKE_OSX_DEPLOYMENT_TARGET "11.0" CACHE STRING "Minimum OS X deployment version")
- SET(CMAKE_CXX_FLAGS_DEBUG "$ENV{CXXFLAGS} -O0 -Wall -g -ggdb --std=c++11 ")
- SET(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall --std=c++11 ")
-
-#设置执行文件输出目录
+# Set output directories
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
-
-#设置库输出路径
 SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
-#头文件搜索目录
-INCLUDE_DIRECTORIES(/usr/local/include ${PROJECT_SOURCE_DIR} .)
+# Add include directories
+INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/deps/miniz)
 
-
-#链接库搜索路径
+# Add library search directories
 LINK_DIRECTORIES(/usr/local/lib ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
-# 添加子目录
+# Add subdirectories
 ADD_SUBDIRECTORY(deps)
 
-# ADD_SUBDIRECTORY(tests)
+# Library target: mdict
+ADD_LIBRARY(mdict STATIC mdict.cc binutils.cc xmlutils.cc ripemd128.c adler32.cc mdict_extern.cc)
+target_link_libraries(mdict PRIVATE miniz)
 
-
-
+# Executable target: mydict (for development/testing purposes only)
 ADD_EXECUTABLE(mydict mdict.cc binutils.cc xmlutils.cc ripemd128.c adler32.cc mdict_extern.cc mdict_extern_test.cc)
-TARGET_LINK_LIBRARIES(mydict miniz)
+target_link_libraries(mydict PRIVATE miniz)
 
-# most important library
-ADD_LIBRARY(mdict mdict.cc binutils.cc xmlutils.cc ripemd128.c adler32.cc mdict_extern.cc)
-
-# adler32 test
+# Test executables
 ADD_EXECUTABLE(adler32_test adler32.cc adler32_test.cc binutils.cc)
-
-# ripemd128 test
 ADD_EXECUTABLE(ripemd128_test ripemd128_test.c ripemd128.c)
-
-# xmlutils
 ADD_EXECUTABLE(xmlutils_test xmlutils.cc xmlutils_test.cc)
-
 ADD_EXECUTABLE(binutils_test binutils.cc binutils_test.cc)
+
+# Define installation behavior for the mdict library
+OPTION(INSTALL_TO_SYSTEM "Install the mdict library to the system" OFF)
+
+if(INSTALL_TO_SYSTEM)
+    # Detect operating system and set library installation paths accordingly
+    if(UNIX AND NOT APPLE)
+        # For Linux
+        set(LIB_INSTALL_DIR "/usr/lib")
+        set(INCLUDE_INSTALL_DIR "/usr/include")
+    elseif(APPLE)
+        # For macOS
+        set(LIB_INSTALL_DIR "/usr/local/lib")
+        set(INCLUDE_INSTALL_DIR "/usr/local/include")
+    elseif(${CMAKE_SYSTEM_NAME} MATCHES ".*BSD")
+        # For BSD systems
+        set(LIB_INSTALL_DIR "/usr/local/lib")
+        set(INCLUDE_INSTALL_DIR "/usr/local/include")
+    else()
+        message(FATAL_ERROR "Unsupported operating system for installation")
+    endif()
+
+    # Install the mdict library
+    install(TARGETS mdict
+        ARCHIVE DESTINATION ${LIB_INSTALL_DIR}
+        LIBRARY DESTINATION ${LIB_INSTALL_DIR}
+    )
+    # Install headers
+    install(FILES mdict.h binutils.h xmlutils.h ripemd128.h adler32.h zlib_wrapper.h
+        DESTINATION ${INCLUDE_INSTALL_DIR}/mdict
+    )
+endif()

--- a/xmlutils.cc
+++ b/xmlutils.cc
@@ -16,6 +16,9 @@
  */
 #include <iostream>
 #include <map>
+#include <string>
+#include <cassert>
+#include "xmlutils.h"
 
 std::map<std::string, std::string> parseXMLHeader(std::string dicxml) {
   /// std::map<char*, char*> headTag;

--- a/xmlutils.h
+++ b/xmlutils.h
@@ -19,6 +19,9 @@
 #define MDICT_XMLUTILS_H_
 
 #include <map>
+#include <string>
+#include <cassert>
+#include <iostream>
 
 // parse xml header info
 std::map<std::string, std::string> parseXMLHeader(std::string dicxml);

--- a/xmlutils_test.cc
+++ b/xmlutils_test.cc
@@ -1,6 +1,6 @@
 #include <xmlutils.h>
+#include <string>
 #include <cassert>
-
 #include <iostream>
 
 using namespace std;


### PR DESCRIPTION
this PR adds support for installing the library in the system when using the following option:
```shell
cmake .. -DINSTALL_TO_SYSTEM=ON
```
it doesn't change the current method of building that is mentioned in the README, like for example:
``` shell
mkdir build
cd build
cmake ..
make mydict
``` 
and so on