### PR TITLE
use decoders by default

### DIFF
--- a/mdict_extern_test.cc
+++ b/mdict_extern_test.cc
@@ -85,10 +85,10 @@ int main(int argc, char **argv) {
       // Convert using our function
       // char* utf8_def = hex_string_to_utf8(definition);
         
-      std::cout << "Key: " << key->key_word 
+      std::cout << "Key: " << hex_string_to_utf8(key->key_word) 
 		<< "\nHex length: " << strlen(definition)
 		<< "\nUTF-8 length: " << (definition ? strlen(definition) : 0)
-    << "\n definition: " << definition
+		<< "\n definition: " << base64_from_hex(definition)
 		<< "\n-------------------------\n";
         
   //     if (utf8_def) {


### PR DESCRIPTION
this makes the output human-readable by default

![image](https://github.com/user-attachments/assets/dfaf2034-366c-48d2-b78c-4b751b2e5439)

the filename wasnt given in utf8 , it was binary , and this is rather annoying.
i tested the our new base64 library that you've added, and it's quite fast, so encoding media by default would be great too