### PR TITLE
export mime_detect in C header

### DIFF
--- a/src/include/mdict_extern.h
+++ b/src/include/mdict_extern.h
@@ -118,6 +118,9 @@ void mdict_stem(void *dict, char *word, char **suggested_words, int length);
  */
 int mdict_destory(void *dict);
 
+// C wrapper for mime_detect
+const char* c_mime_detect(const char* filename);
+  
 //-------------------------
 
 #ifdef __cplusplus

--- a/src/mdict_extern.cc
+++ b/src/mdict_extern.cc
@@ -166,6 +166,16 @@ int mdict_destory(void *dict) {
   return 0;
 }
 
+
+const char* c_mime_detect(const char* filename) {
+    static std::string result;       // keep it alive after return
+    result = mime_detect(filename);  
+    return result.c_str();
+}
+
+  
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
we forgot to export that function , lol

i've realized it when trying to use base64 in the haskell bindings:
https://git.ajattix.org/hashirama/mdict-hs/commit/7662e70abb3e8aea77f2e9bc0eb4f82bfd8d5d43