### PR TITLE
Add the parameter DNDEBUG in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 # Set build type and compilation flags
 SET(CMAKE_CXX_FLAGS_DEBUG "$ENV{CXXFLAGS} -O0 -Wall -g -ggdb --std=c++17 ")
-SET(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall --std=c++17 ")
+SET(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall -DNDEBUG --std=c++17 ")
 
 # Set output directories
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)


### PR DESCRIPTION
When my app uses libmdict.a in release mode, it crashes. The error is below:

```
Assertion failed: (num_entries_counter == this->entries_num), function decode_key_block_info, file mdict.cc, line 1358.
```