### PR TITLE
accomodate more bytes

### DIFF
--- a/src/encode/char_decoder.h
+++ b/src/encode/char_decoder.h
@@ -134,11 +134,17 @@ inline ssize_t utf16le_to_utf8(const unsigned char *utf16le_data, size_t utf16le
 
         // Check buffer space *before* writing
         // Need space for the bytes + 1 for potential null terminator later
-        if (utf8_idx + bytes_needed >= utf8_buf_len) { // Use >= to ensure space for null term
-             fprintf(stderr, "Error: Output UTF-8 buffer (size %zu) too small. Needs at least %zu bytes (+ null).\n",
-                     utf8_buf_len, utf8_idx + bytes_needed + 1);
-             return -1; // Buffer overflow
-        }
+        if (utf8_idx + bytes_needed >= utf8_buf_len) {
+            size_t new_len = (utf8_idx + bytes_needed) * 2; // grow a bit more to reduce future reallocs
+             char* new_buf = (char*)realloc(utf8_buf, new_len);
+           if (!new_buf) {
+             fprintf(stderr, "Error: Failed to allocate memory for UTF-8 buffer\n");
+             return -1;
+          }
+              utf8_buf = new_buf;
+             utf8_buf_len = new_len;
+	}
+
 
         // Write the UTF-8 bytes
         if (bytes_needed == 1) {

--- a/src/encode/char_decoder.h
+++ b/src/encode/char_decoder.h
@@ -141,7 +141,7 @@ inline ssize_t utf16le_to_utf8(const unsigned char *utf16le_data, size_t utf16le
              fprintf(stderr, "Error: Failed to allocate memory for UTF-8 buffer\n");
              return -1;
           }
-              utf8_buf = new_buf;
+             utf8_buf = reinterpret_cast<unsigned char*>(new_buf);
              utf8_buf_len = new_len;
 	}
 

--- a/src/mdict_extern.cc
+++ b/src/mdict_extern.cc
@@ -70,29 +70,47 @@ void *mdict_init(const char *dictionary_path) {
 /**
  lookup a word
  */
-void mdict_lookup(void *dict, const char *word, char **result) {
-  auto *self = (mdict::Mdict *)dict;
-  std::string queryWord(word);
-  std::string s = self->lookup(queryWord);
 
-  (*result) = (char *)calloc(sizeof(char), s.size() + 1);
-  std::copy(s.begin(), s.end(), (*result));
-  (*result)[s.size()] = '\0';
+void mdict_lookup(void *dict, const char *word, char **result) {
+    auto *self = (mdict::Mdict *)dict;
+    std::string queryWord(word);
+
+    std::string s = self->lookup(queryWord);
+
+    // Create vector with null terminator
+    std::vector<char> buf(s.begin(), s.end());
+    buf.push_back('\0');
+
+    // Allocate result buffer once, copy vector content
+    *result = (char*)malloc(buf.size());
+    if (!*result) {
+        perror("malloc");
+        return;
+    }
+    memcpy(*result, buf.data(), buf.size());
 }
+
 
 /**
  locate a word
  */
-void mdict_locate(void *dict, const char *word, char **result,
-                  mdict_encoding_t encoding) {
-  auto *self = (mdict::Mdict *)dict;
-  std::string queryWord(word);
-  std::string s = self->locate(queryWord, encoding);
+void mdict_locate(void *dict, const char *word, char **result, mdict_encoding_t encoding) {
+    auto *self = (mdict::Mdict *)dict;
+    std::string queryWord(word);
 
-  (*result) = (char *)calloc(sizeof(char), s.size() + 1);
-  std::copy(s.begin(), s.end(), (*result));
-  (*result)[s.size()] = '\0';
+    std::string s = self->locate(queryWord, encoding);
+
+    std::vector<char> buf(s.begin(), s.end());
+    buf.push_back('\0');
+
+    *result = (char*)malloc(buf.size());
+    if (!*result) {
+        perror("malloc");
+        return;
+    }
+    memcpy(*result, buf.data(), buf.size());
 }
+
 
 void mdict_parse_definition(void *dict, const char *word,
                             unsigned long record_start, char **result) {


### PR DESCRIPTION
when doing a bulk-search , sometimes (for a unknown reason) the function does not allocate enough space for the whole process, we fix that by allocating n*2 

this commit will be complemented by a change in mdict_extern.cc that also changes how memory allocation is done in there