### PR TITLE
Stof removal and replacement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ SET(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall --std=c++17 ")
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
-ADD_COMPILE_OPTIONS(-Wno-unused-variable -fpermissive -Wno-sign-compare)
+ADD_COMPILE_OPTIONS(-Wno-unused-variable -fpermissive -Wno-sign-compare -Wno-error=sign-compare)
 
 # Add cmake modules path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ SET(CMAKE_CXX_FLAGS_RELEASE "$ENV{CXXFLAGS} -O3 -Wall --std=c++17 ")
 SET(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 SET(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/lib)
 
-ADD_COMPILE_OPTIONS(-Wno-unused-variable -fpermissive)
+ADD_COMPILE_OPTIONS(-Wno-unused-variable -fpermissive -Wno-sign-compare)
 
 # Add cmake modules path
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")

--- a/src/encode/api.h
+++ b/src/encode/api.h
@@ -96,7 +96,7 @@ inline std::string trim_nulls(const std::string& s) {
 // c++ territory
 
 // meant to be used when checking dictionary headers
-inline bool utf16_to_utf8_header(const char* src, size_t src_len, std::string& out) {
+inline bool utf16_to_utf8_header(const unsigned char* src, size_t src_len, std::string& out) {
     if (!src) return false;
     if (src_len == 0) { out.clear(); return true; }
 
@@ -111,7 +111,11 @@ inline bool utf16_to_utf8_header(const char* src, size_t src_len, std::string& o
     // allocate string buffer with null characters
     out.assign(out_capacity, '\0');
 
-    ssize_t written = utf16le_to_utf8_compat(src, src_len, &out[0], out_capacity);
+    // cast internally only where needed
+    ssize_t written = utf16le_to_utf8_compat(
+        reinterpret_cast<const char*>(src), src_len, &out[0], out_capacity
+    );
+
     if (written < 0 || static_cast<size_t>(written) > out_capacity) {
         out.clear();
         return false;

--- a/src/encode/api.h
+++ b/src/encode/api.h
@@ -90,3 +90,31 @@ inline std::string trim_nulls(const std::string& s) {
     if (end == std::string::npos) return ""; // all nulls
     return s.substr(0, end + 1);
 }
+
+// meant to be used when checking dictionary headers
+inline bool utf16_to_utf8_header(const char* src, size_t src_len, std::string& out) {
+    if (!src) return false;
+    if (src_len == 0) { out.clear(); return true; }
+
+    // worst-case: 4 bytes per UTF16 unit
+    size_t out_capacity = src_len * 4;
+
+    // sanity check against API limits
+    if (out_capacity > static_cast<size_t>(INT_MAX) || src_len > static_cast<size_t>(INT_MAX)) {
+        return false;
+    }
+
+    // allocate string buffer with null characters
+    out.assign(out_capacity, '\0');
+
+    ssize_t written = utf16le_to_utf8_compat(src, src_len, &out[0], out_capacity);
+    if (written < 0 || static_cast<size_t>(written) > out_capacity) {
+        out.clear();
+        return false;
+    }
+
+    // shrink to actual written size
+    out.resize(static_cast<size_t>(written));
+    return true;
+}
+

--- a/src/encode/api.h
+++ b/src/encode/api.h
@@ -11,6 +11,8 @@
 #include <string>
 #pragma once
 #include "char_decoder.h"
+#include <cstdlib> // for size_t
+#include <climits> // for INT_MAX
 
 // Safe casting wrapper
 static inline unsigned char* malloc_uc(size_t size) {
@@ -91,6 +93,8 @@ inline std::string trim_nulls(const std::string& s) {
     return s.substr(0, end + 1);
 }
 
+// c++ territory
+
 // meant to be used when checking dictionary headers
 inline bool utf16_to_utf8_header(const char* src, size_t src_len, std::string& out) {
     if (!src) return false;
@@ -117,4 +121,3 @@ inline bool utf16_to_utf8_header(const char* src, size_t src_len, std::string& o
     out.resize(static_cast<size_t>(written));
     return true;
 }
-

--- a/src/mdict.cc
+++ b/src/mdict.cc
@@ -112,12 +112,10 @@ void Mdict::read_header() {
   // header text utf16
 
   std::string utf8_temp;
-  if (!utf16_to_utf8_header(reinterpret_cast<const unsigned char*>(head_buffer),
-                          header_bytes_size, utf8_temp)) {
+  if (!utf16_to_utf8_header(head_buffer, header_bytes_size, utf8_temp)) {
     std::cout << "this mdx file is invalid len:" << header_bytes_size << std::endl;
     return;
-}
-
+  }
 
   unsigned char* utf8_buffer = reinterpret_cast<unsigned char*>(&utf8_temp[0]);
   int utf8_len = static_cast<int>(utf8_temp.size());


### PR DESCRIPTION
as mentioned in https://github.com/dictlab/mdict-cpp/issues/43#issuecomment-3315454192

it does not solve the ```entries``` problem, which haven't been debugged yet, and probably requires knowledge of how the MDict format works