### PR TITLE
feat: added flag BUILD_SHARED to build the shared lib libmdict.so

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,8 +48,16 @@ LINK_DIRECTORIES(/usr/local/lib ${CMAKE_CURRENT_BINARY_DIR}/lib)
 # Add subdirectories
 ADD_SUBDIRECTORY(tests)
 
+# Set the option to static or shared library
+OPTION(BUILD_SHARED "Build mdict as a shared library instead of static" OFF)
+
 # Library target: mdict
-ADD_LIBRARY(mdict STATIC src/mdict.cc src/binutils.cc src/ripemd128.c src/adler32.cc src/mdict_extern.cc)
+if(BUILD_SHARED)
+	set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+	ADD_LIBRARY(mdict SHARED src/mdict.cc src/binutils.cc src/ripemd128.c src/adler32.cc src/mdict_extern.cc)
+else()
+	ADD_LIBRARY(mdict STATIC src/mdict.cc src/binutils.cc src/ripemd128.c src/adler32.cc src/mdict_extern.cc)
+endif()
 TARGET_LINK_LIBRARIES(mdict PRIVATE mdictminiz mdictbase64)
 
 # Executable target: mydict (for development/testing purposes only)
@@ -105,5 +113,3 @@ if(INSTALL_TO_SYSTEM)
         COMPONENT mydict
     )
 endif()
-
-


### PR DESCRIPTION
I am creating this PR as a start point because I added the line to compile to a shared object (it worked in a docker, to build the shared library), but after using it in my main system it gives me the error:

[ 70%] Linking CXX shared library lib/libmdict.so
/usr/bin/ld: <my-path>/mdict-cpp/build/lib/libmdictbase64.a(turbob64c.c.o): warning: relocation against « stdout@@GLIBC_2.2.5 » in read-only section « .text »
/usr/bin/ld: <my-path>/mdict-cpp/build/lib/libmdictminiz.a(miniz.c.o): relocation R_X86_64_PC32 toward symbol « miniz_def_alloc_func » cannot be used when creating a shared object; recompile with -fPIC
/usr/bin/ld : final link failed: bad value
collect2: error: ld returned 1 exit status
make[2]: *** [CMakeFiles/mdict.dir/build.make:165: lib/libmdict.so] Error 1
make[1]: *** [CMakeFiles/Makefile2:270: CMakeFiles/mdict.dir/all] Error 2
make: *** [Makefile:91: all] Error 2



I looked into it, but I couldn't spot the problem